### PR TITLE
refactor: use an 'id' as an identifier

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ events = [
         "description": "first description",
         "title": "event 1",
         "is_finished": False,
+        "id": 1,
     }
 ]
 


### PR DESCRIPTION
It's better to use a unique 'id' to determine events uniqueness.